### PR TITLE
apk/manifest: Add missing `serde(default)` to `sdk` member

### DIFF
--- a/apk/src/manifest.rs
+++ b/apk/src/manifest.rs
@@ -22,6 +22,7 @@ pub struct AndroidManifest {
     #[serde(rename(serialize = "platformBuildVersionName"))]
     pub platform_build_version_name: Option<u32>,
     #[serde(rename(serialize = "uses-sdk"))]
+    #[serde(default)]
     pub sdk: Sdk,
     #[serde(rename(serialize = "uses-feature"))]
     #[serde(default)]


### PR DESCRIPTION
When declaring an Android manifest the user should not suddenly be
forced to define the `sdk` element with versions, as they're not
required to specify this when omitting the manifest entirely either.

This matches what `android-ndk-rs` is doing from the get-go.

---

@dvc94ch Not entirely sure about this one since `android-ndk-rs` has it since the serde refactor so it isn't something new, perhaps you removed it for good reason?