### PR TITLE
Use `llvm-readelf` to detect and bundle needed dynamic libs for Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       if: ${{ matrix.host == 'macos-latest' }}
     - run: sudo ln -s llvm-ar-13 /usr/${{ matrix.host == 'macos-latest' && 'local/' || '' }}bin/llvm-ar
     - run: sudo ln -s llvm-ar-13 /usr/${{ matrix.host == 'macos-latest' && 'local/' || '' }}bin/llvm-lib
+    - run: sudo ln -s llvm-readobj-13 /usr/${{ matrix.host == 'macos-latest' && 'local/' || '' }}bin/llvm-readobj
     - run: sudo ln -s lld-link-13 /usr/${{ matrix.host == 'macos-latest' && 'local/' || '' }}bin/lld-link
     - run: sudo ln -s lld-13 /usr/${{ matrix.host == 'macos-latest' && 'local/' || '' }}bin/lld
 

--- a/mvn/src/lib.rs
+++ b/mvn/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::metadata::Metadata;
 use crate::package::Artifact;
 use crate::pom::{Dependency, Pom};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};
@@ -127,8 +127,7 @@ impl<D: Download> Maven<D> {
             anyhow::ensure!(downloaded, "metadata not found for {}", package);
         }
         let s = std::fs::read_to_string(path)?;
-        let metadata =
-            quick_xml::de::from_str(&s).map_err(|err| anyhow::anyhow!("{}: {}", err, s))?;
+        let metadata = quick_xml::de::from_str(&s).context(s)?;
         Ok(metadata)
     }
 
@@ -136,8 +135,7 @@ impl<D: Download> Maven<D> {
         match self.artifact(artifact, "pom") {
             Ok(path) => {
                 let s = std::fs::read_to_string(path)?;
-                let pom =
-                    quick_xml::de::from_str(&s).map_err(|err| anyhow::anyhow!("{}: {}", err, s))?;
+                let pom = quick_xml::de::from_str(&s).context(s)?;
                 Ok(pom)
             }
             Err(err) => {

--- a/xbuild/src/command/doctor.rs
+++ b/xbuild/src/command/doctor.rs
@@ -18,7 +18,7 @@ impl Default for Doctor {
                         Check::new("clang++", Some(VersionCheck::new("--version", 0, 2))),
                         Check::new("llvm-ar", None),
                         Check::new("llvm-lib", None),
-                        Check::new("llvm-readelf", Some(VersionCheck::new("--version", 1, 4))),
+                        Check::new("llvm-readobj", Some(VersionCheck::new("--version", 1, 4))),
                         Check::new("lld", Some(VersionCheck::new("-flavor ld --version", 0, 1))),
                         Check::new("lld-link", Some(VersionCheck::new("--version", 0, 1))),
                         Check::new("lldb", Some(VersionCheck::new("--version", 0, 2))),

--- a/xbuild/src/command/doctor.rs
+++ b/xbuild/src/command/doctor.rs
@@ -18,6 +18,7 @@ impl Default for Doctor {
                         Check::new("clang++", Some(VersionCheck::new("--version", 0, 2))),
                         Check::new("llvm-ar", None),
                         Check::new("llvm-lib", None),
+                        Check::new("llvm-readelf", Some(VersionCheck::new("--version", 1, 4))),
                         Check::new("lld", Some(VersionCheck::new("-flavor ld --version", 0, 1))),
                         Check::new("lld-link", Some(VersionCheck::new("--version", 0, 1))),
                         Check::new("lldb", Some(VersionCheck::new("--version", 0, 2))),

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -300,6 +300,7 @@ impl CompileTarget {
             (Arch::Arm64, Platform::Ios) => "aarch64-apple-ios",
             (Arch::Arm64, Platform::Linux) => "aarch64-unknown-linux-gnu",
             (Arch::Arm64, Platform::Macos) => "aarch64-apple-darwin",
+            (Arch::X64, Platform::Android) => "x86_64-linux-android",
             (Arch::X64, Platform::Linux) => "x86_64-unknown-linux-gnu",
             (Arch::X64, Platform::Macos) => "x86_64-apple-darwin",
             (Arch::X64, Platform::Windows) => "x86_64-pc-windows-msvc",
@@ -309,6 +310,10 @@ impl CompileTarget {
                 platform
             ),
         })
+    }
+
+    pub fn is_host(self) -> Result<bool> {
+        Ok(self.platform() == Platform::host()? && self.arch() == Arch::host()?)
     }
 }
 

--- a/xcommon/Cargo.toml
+++ b/xcommon/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 anyhow = "1.0.65"
 byteorder = "1.4.3"
+dunce = "1"
 image = { version = "0.24.4", default-features = false, features = ["png"] }
 pem = "1.1.0"
 rasn = "0.6.1"

--- a/xcommon/src/lib.rs
+++ b/xcommon/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod llvm;
+
 use anyhow::{Context, Result};
 use byteorder::{LittleEndian, ReadBytesExt};
 use image::imageops::FilterType;

--- a/xcommon/src/llvm.rs
+++ b/xcommon/src/llvm.rs
@@ -69,7 +69,7 @@ pub fn list_needed_libs_recursively(
 
 /// List all required shared libraries as per the dynamic section
 fn list_needed_libs(library_path: &Path) -> Result<HashSet<String>> {
-    let mut readelf = Command::new("llvm-readelf");
+    let mut readelf = Command::new("llvm-readobj");
     let readelf = readelf.arg("--needed-libs").arg(library_path);
     let output = readelf
         .output()
@@ -81,7 +81,7 @@ fn list_needed_libs(library_path: &Path) -> Result<HashSet<String>> {
         output.status
     );
     let output = std::str::from_utf8(&output.stdout).unwrap();
-    let output = output.strip_prefix("NeededLibraries [\n").unwrap();
+    let (_, output) = output.split_once("NeededLibraries [\n").unwrap();
     let output = output.strip_suffix("]\n").unwrap();
     let mut needed = HashSet::new();
 

--- a/xcommon/src/llvm.rs
+++ b/xcommon/src/llvm.rs
@@ -1,0 +1,121 @@
+//! LLVM utilities
+
+use anyhow::{bail, ensure, Context, Result};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Returns the set of additional libraries that need to be bundled with
+/// the given library, scanned recursively.
+///
+/// Any libraries in `provided_libs_paths` will be treated as available, without
+/// being emitted. Any other library not in `search_paths` or `provided_libs_paths`
+/// will result in an error.
+pub fn list_needed_libs_recursively(
+    lib: &Path,
+    search_paths: &[&Path],
+    provided_libs_paths: &[&Path],
+) -> Result<HashSet<PathBuf>> {
+    // Create a view of all libraries that are available on Android
+    let mut provided = HashSet::new();
+    for path in provided_libs_paths {
+        for lib in find_libs_in_dir(path).with_context(|| {
+            format!("Unable to list available libraries in `{}`", path.display())
+        })? {
+            // libc++_shared is bundled with the NDK but not available on-device
+            if lib != "libc++_shared.so" {
+                provided.insert(lib);
+            }
+        }
+    }
+
+    let mut to_copy = HashSet::new();
+
+    let mut artifacts = vec![lib.to_path_buf()];
+    while let Some(artifact) = artifacts.pop() {
+        for need in list_needed_libs(&artifact).with_context(|| {
+            format!(
+                "Unable to read needed libraries from `{}`",
+                artifact.display()
+            )
+        })? {
+            // c++_shared is available in the NDK but not on-device.
+            // Must be bundled with the apk if used:
+            // https://developer.android.com/ndk/guides/cpp-support#libc
+            let search_paths = if need == "libc++_shared.so" {
+                provided_libs_paths
+            } else {
+                search_paths
+            };
+
+            if provided.insert(need.clone()) {
+                if let Some(path) = find_library_path(search_paths, &need).with_context(|| {
+                    format!(
+                        "Could not iterate one or more search directories in `{:?}` while searching for library `{}`",
+                        search_paths, need
+                    )
+                })? {
+                    to_copy.insert(path.clone());
+                    artifacts.push(path);
+                } else {
+                    bail!("Shared library `{}` not found", need);
+                }
+            }
+        }
+    }
+
+    Ok(to_copy)
+}
+
+/// List all required shared libraries as per the dynamic section
+fn list_needed_libs(library_path: &Path) -> Result<HashSet<String>> {
+    let mut readelf = Command::new("llvm-readelf");
+    let readelf = readelf.arg("--needed-libs").arg(library_path);
+    let output = readelf
+        .output()
+        .with_context(|| format!("Failed to run `{:?}`", readelf))?;
+    ensure!(
+        output.status.success(),
+        "Failed to run `{:?}`: {}",
+        readelf,
+        output.status
+    );
+    let output = std::str::from_utf8(&output.stdout).unwrap();
+    let output = output.strip_prefix("NeededLibraries [\n").unwrap();
+    let output = output.strip_suffix("]\n").unwrap();
+    let mut needed = HashSet::new();
+
+    for line in output.lines() {
+        let lib = line.trim_start();
+        needed.insert(lib.to_string());
+    }
+    Ok(needed)
+}
+
+/// List names of shared libraries inside directory
+fn find_libs_in_dir(path: &Path) -> Result<HashSet<String>> {
+    let mut libs = HashSet::new();
+    let entries = std::fs::read_dir(path)?;
+    for entry in entries {
+        let entry = entry?;
+        if !entry.path().is_dir() {
+            if let Some(file_name) = entry.file_name().to_str() {
+                if file_name.ends_with(".so") {
+                    libs.insert(file_name.to_string());
+                }
+            }
+        }
+    }
+    Ok(libs)
+}
+
+/// Resolves native library using search paths
+fn find_library_path(paths: &[&Path], library: &str) -> Result<Option<PathBuf>> {
+    for path in paths {
+        let lib_path = path.join(library);
+        if lib_path.exists() {
+            return Ok(Some(dunce::canonicalize(lib_path)?));
+        }
+    }
+    Ok(None)
+}


### PR DESCRIPTION
Fixes #47

Dynamic libraries that a Rust library links against while not being present on the target platform (`libc++_shared.so` and other custom libraries) need to be bundled in the APK specifically.  This approach is adopted frm `android-ndk-rs` while switching from `readelf` to `llvm-readelf`.
