### PR TITLE
xbuild: Build APKs instead of AABs in release mode, until supported

### DIFF
--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -205,7 +205,8 @@ pub fn build(env: &BuildEnv) -> Result<()> {
             }
         }
         Platform::Android => {
-            let out = platform_dir.join(format!("{}.apk", env.name()));
+            let out = platform_dir.join(format!("{}.{}", env.name(), env.target().format()));
+
             let mut apk = Apk::new(
                 out,
                 env.manifest().android().clone(),

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -185,7 +185,7 @@ impl Format {
     pub fn platform_default(platform: Platform, opt: Opt) -> Self {
         match (platform, opt) {
             (Platform::Android, Opt::Debug) => Self::Apk,
-            (Platform::Android, Opt::Release) => Self::Aab,
+            (Platform::Android, Opt::Release) => Self::Apk, /* TODO: Aab is not currently supported */
             (Platform::Ios, Opt::Debug) => Self::Appbundle,
             (Platform::Ios, Opt::Release) => Self::Ipa,
             (Platform::Linux, Opt::Debug) => Self::Appdir,


### PR DESCRIPTION
It seems like the Android App Bundle support isn't in place yet, though most of the codebase depends on it when building in `--release`.  Fall back to creating standard ol' APKs for now until someone gets around to implementing this.
