### PR TITLE
devices/adb: Launch app with `ACTION_MAIN`, not `ACTION_RUN`

### DIFF
--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -96,7 +96,7 @@ impl Adb {
             .arg("am")
             .arg("start")
             .arg("-a")
-            .arg("android.intent.action.RUN")
+            .arg("android.intent.action.MAIN")
             .arg("-n")
             .arg(format!("{}/{}", package, activity))
             .status()?;


### PR DESCRIPTION
`ACTION_MAIN` is what `cargo-apk` uses and what both it and `xbuild` create the Activity `intent-filter` with in `AndroidManifest.xml`.  With `android.intent.action.RUN`, on at least a recently updated phone to Android 13, this `am start` call otherwise fails with:

    Starting: Intent { act=android.intent.action.RUN cmp=nl.my_app/android.app.NativeActivity }
    Error type 3
    Error: Activity class {nl.my_app/android.app.NativeActivity} does not exist.
