### PR TITLE
xbuild/cargo: Pass features with `--features` or `-F` to `cargo`

### DIFF
--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -12,6 +12,7 @@ pub use artifact::{Artifact, CrateType};
 
 pub struct Cargo {
     package: String,
+    features: Vec<String>,
     manifest: PathBuf,
     target_dir: PathBuf,
     offline: bool,
@@ -20,6 +21,7 @@ pub struct Cargo {
 impl Cargo {
     pub fn new(
         package: Option<&str>,
+        features: Vec<String>,
         manifest_path: Option<PathBuf>,
         target_dir: Option<PathBuf>,
         offline: bool,
@@ -52,6 +54,7 @@ impl Cargo {
         });
         Ok(Self {
             package,
+            features,
             manifest,
             target_dir,
             offline,
@@ -91,7 +94,13 @@ impl Cargo {
     }
 
     pub fn build(&self, target: CompileTarget, target_dir: &Path) -> Result<CargoBuild> {
-        CargoBuild::new(target, self.root_dir(), target_dir, self.offline)
+        CargoBuild::new(
+            target,
+            &self.features,
+            self.root_dir(),
+            target_dir,
+            self.offline,
+        )
     }
 
     pub fn artifact(
@@ -178,6 +187,7 @@ pub struct CargoBuild {
 impl CargoBuild {
     fn new(
         target: CompileTarget,
+        features: &[String],
         root_dir: &Path,
         target_dir: &Path,
         offline: bool,
@@ -199,6 +209,9 @@ impl CargoBuild {
         }
         if offline {
             cmd.arg("--offline");
+        }
+        for features in features {
+            cmd.arg("--features").arg(features);
         }
         Ok(Self {
             cmd,

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -348,12 +348,16 @@ pub struct CargoArgs {
     /// Run without accessing the network
     #[clap(long)]
     offline: bool,
+    /// Space or comma separated list of features to activate
+    #[clap(short = 'F', long)]
+    features: Vec<String>,
 }
 
 impl CargoArgs {
     pub fn cargo(self) -> Result<Cargo> {
         Cargo::new(
             self.package.as_deref(),
+            self.features,
             self.manifest_path,
             self.target_dir,
             self.offline,


### PR DESCRIPTION
In order to build projects with features in `xbuild`, it has to accept these on the command line and pass them on to the underlying `cargo` invocation.
